### PR TITLE
Alternative syntax for objects

### DIFF
--- a/B0.ml
+++ b/B0.ml
@@ -56,6 +56,10 @@ let cookbook =
 let trials =
   test ~/"test/trials.ml" ~run:false ~doc:"Experiments"
 
+let test_syntax =
+  test ~/"test/test_syntax.ml" ~run:false ~doc:"Test art-w's syntax performance"
+    ~requires:[jsont_bytesrw]
+
 let topojson =
   let doc = "Jsont modelling of TopoJSON" in
   let requires = [cmdliner; bytesrw; jsont_bytesrw] in

--- a/src/jsont.ml
+++ b/src/jsont.ml
@@ -163,9 +163,9 @@ module Repr = struct (* See the .mli for documentation *)
   module String_map = Map.Make (String)
   module Type = Jsont_base.Type
 
-  type ('ret, 'f) dec_fun =
-  | Dec_fun : 'f -> ('ret, 'f) dec_fun
-  | Dec_app : ('ret, 'a -> 'b) dec_fun * 'a Type.Id.t -> ('ret, 'b) dec_fun
+  type 'f dec_fun =
+  | Dec_fun : 'f -> 'f dec_fun
+  | Dec_app : ('a -> 'b) dec_fun * 'a Type.Id.t -> 'b dec_fun
 
   type ('a, 'b) base_map =
   { kind : string;
@@ -199,7 +199,7 @@ module Repr = struct (* See the .mli for documentation *)
   and ('o, 'dec) object_map =
   { kind : string;
     doc : string;
-    dec : ('o, 'dec) dec_fun;
+    dec : 'dec dec_fun;
     mem_decs : mem_dec String_map.t;
     mem_encs : 'o mem_enc list;
     enc_meta : 'o -> Meta.t;
@@ -400,7 +400,7 @@ module Repr = struct (* See the .mli for documentation *)
         | Some Type.Equal -> Some v | None -> assert false
   end
 
-  let rec apply_dict : type ret f. (ret, f) dec_fun -> Dict.t -> f =
+  let rec apply_dict : type f. f dec_fun -> Dict.t -> f =
   fun dec dict -> match dec with
   | Dec_fun f -> f
   | Dec_app (f, arg) -> (apply_dict f dict) (Option.get (Dict.find arg dict))

--- a/src/jsont.mli
+++ b/src/jsont.mli
@@ -1663,10 +1663,10 @@ module Repr : sig
     end
   end
 
-  type ('ret, 'f) dec_fun =
-  | Dec_fun : 'f -> ('ret, 'f) dec_fun
-    (** The function and its return type. *)
-  | Dec_app : ('ret, 'a -> 'b) dec_fun * 'a Type.Id.t -> ('ret, 'b) dec_fun
+  type 'f dec_fun =
+  | Dec_fun : 'f -> 'f dec_fun
+    (** The function. *)
+  | Dec_app : ('a -> 'b) dec_fun * 'a Type.Id.t -> 'b dec_fun
     (** Application of an argument to a function witnessed by a type
         identifier. The type identifier can be used to lookup a value
         of the right type in an heterogenous dictionary. *)
@@ -1741,8 +1741,8 @@ module Repr : sig
     (** The kind of JSON object (documentation). *)
     doc : string;
     (** A doc string for the JSON member. *)
-    dec : ('o, 'dec) dec_fun;
-    (** The object decoding function to construct an ['o] value. *)
+    dec : 'dec dec_fun;
+    (** The object decoding function to construct a ['dec] value. *)
     mem_decs : mem_dec String_map.t;
     (** [mem_decs] are the member decoders sorted by member name. *)
     mem_encs : 'o mem_enc list;
@@ -2006,7 +2006,7 @@ module Repr : sig
     val find : 'a Type.Id.t -> t -> 'a option
   end
 
-  val apply_dict : ('ret, 'f) dec_fun -> Dict.t -> 'f
+  val apply_dict : 'f dec_fun -> Dict.t -> 'f
   (** [apply_dict dec dict] applies [dict] to [f] in order to get the
       value ['f]. Raises [Invalid_argument] if [dict] has not all the
       type identifiers that [dec] needs. *)

--- a/src/jsont.mli
+++ b/src/jsont.mli
@@ -1716,8 +1716,10 @@ module Repr : sig
   type 'f dec_fun =
   | Dec_fun : 'f -> 'f dec_fun
     (** The function. *)
-  | Dec_app : ('a -> 'b) dec_fun * 'a Type.Id.t -> 'b dec_fun
-    (** Application of an argument to a function witnessed by a type
+  | Dec_app : ('a -> 'b) dec_fun * 'a dec_fun -> 'b dec_fun
+    (** Application of an argument to a function. *)
+  | Dec_arg : 'a Type.Id.t -> 'a dec_fun
+    (** An argument for a function witnessed by a type
         identifier. The type identifier can be used to lookup a value
         of the right type in an heterogenous dictionary. *)
   (** The type for decoding functions. *)

--- a/src/jsont.mli
+++ b/src/jsont.mli
@@ -990,6 +990,56 @@ module Object : sig
       A shortcut to represent optional members of type ['a] with ['a option]
       values. *)
 
+  module Syntax : sig
+    type ('o, 'a) schema
+    (** The type for mapping a member object to a value ['a] stored
+        in an OCaml value of type ['o]. *)
+
+    val define : ?kind:string -> ?doc:string -> ('o, 'o) schema -> 'o t
+    (** [define ?kind ?doc schema] is a JSON type for objects described by
+        [schema]. [kind] names the entities represented by the map and [doc]
+        documents them. Both default to [""].
+
+        Raises [Invalid_argument] if [schema] describes a member name more than
+        once. *)
+
+    val mem :
+      ?doc:string -> ?dec_absent:'a -> ?enc:('o -> 'a) ->
+      ?enc_omit:('a -> bool) -> string -> 'a t -> ('o, 'a) schema
+    (** [mem name t] is a member named [name] of type [t] for an object of
+        type ['o] being defined.
+        {ul
+        {- [doc] is a documentation string for the member. Defaults to [""].}
+        {- [dec_absent], if specified, is the value used for the decoding
+           direction when the member named [name] is missing. If unspecified
+           decoding errors when the member is absent. See also {!opt_mem}.
+        {- [enc] is used to project the member's value from the object
+           representation ['o] for encoding to JSON with [t]. It can be omitted
+           if the result is only used for decoding.}
+        {- [enc_omit] is for the encoding direction. If the member value
+           returned by [enc] returns [true] on [enc_omit], the member is omited
+           in the encoded JSON object. Defaults to [Fun.const false].}} *)
+
+    val opt_mem :
+      ?doc:string -> ?enc:('o -> 'a option) -> string -> 'a t ->
+      ('o, 'a option) schema
+    (** [opt_mem name t] is:
+    {[
+      let dec_absent = None and enc_omit = Option.is_none in
+      Jsont.Object.Syntax.mem name (Jsont.some t) map ~dec_absent ~enc_omit
+    ]}
+        A shortcut to represent optional members of type ['a] with ['a option]
+        values. *)
+
+    val ( let+ ) : ('o, 'a) schema -> ('a -> 'b) -> ('o, 'b) schema
+    (** [let+ v = schema in body] maps the member value [v] to [body]. *)
+
+    val ( and+ ) : ('o, 'a) schema -> ('o, 'b) schema -> ('o, 'a * 'b) schema
+    (** [let+ x = a and+ y = b in body] combines two (or more) schemas
+        [a] and [b] together, using [body] to join their member values
+        [x] and [y]. *)
+  end
+
   (** {1:cases Case objects}
 
       Read the {{!page-cookbook.cases}cookbook} on case objects. *)

--- a/test/test_common_samples.ml
+++ b/test/test_common_samples.ml
@@ -107,11 +107,13 @@ module Cases = struct
       let book_count a = a.book_count
       let pseudo a = a.pseudo
       let jsont =
-        Jsont.Object.map ~kind:"Author" make
-        |> Jsont.Object.mem "name" Jsont.string ~enc:name
-        |> Jsont.Object.mem "book_count" Jsont.int ~enc:book_count
-        |> Jsont.Object.mem "pseudo" Jsont.string ~enc:pseudo
-        |> Jsont.Object.finish
+        let open Jsont.Object.Syntax in
+        define ~kind:"Author" @@
+        let+ name = mem "name" Jsont.string ~enc:name
+        and+ book_count = mem "book_count" Jsont.int ~enc:book_count
+        and+ pseudo = mem "pseudo" Jsont.string ~enc:pseudo
+        in
+        { name; book_count; pseudo }
     end
 
     module Editor = struct

--- a/test/test_syntax.ml
+++ b/test/test_syntax.ml
@@ -1,0 +1,108 @@
+(*---------------------------------------------------------------------------
+   Copyright (c) 2024 The jsont programmers. All rights reserved.
+   SPDX-License-Identifier: ISC
+  ---------------------------------------------------------------------------*)
+
+type t =
+  { name : string;
+    pseudo : string;
+    book_count : int;
+    address : string;
+    email : string; }
+
+let make name book_count pseudo address email =
+  { name; pseudo; book_count; address; email }
+  
+let make_rand st =
+  let rand_name st ~max =
+    let alpha st = Char.chr (0x61 + Random.State.int st (0x7A - 0x61 + 1)) in
+    String.init (Random.State.int st (max + 1)) (fun _ -> alpha st)
+  in
+  let name = rand_name st ~max:15 in
+  let pseudo = rand_name st ~max:15 in
+  let book_count = Random.State.int st 20 in
+  let address = rand_name st ~max:20 in
+  let email = rand_name st ~max:20 in
+  { name; pseudo; book_count; address; email }
+
+let name p = p.name
+let pseudo p = p.pseudo
+let book_count p = p.book_count
+let address p = p.address
+let email p = p.email
+                
+let author_jsont =
+  Jsont.Object.map ~kind:"Author" make
+  |> Jsont.Object.mem "name" Jsont.string ~enc:name
+  |> Jsont.Object.mem "book_count" Jsont.int ~enc:book_count
+  |> Jsont.Object.mem "pseudo" Jsont.string ~enc:pseudo
+  |> Jsont.Object.mem "address" Jsont.string ~enc:address
+  |> Jsont.Object.mem "email" Jsont.string ~enc:email
+  |> Jsont.Object.finish
+       
+let author_jsont_syntax =
+  let open Jsont.Object.Syntax in
+  define ~kind:"Author" @@
+  let+ name = mem "name" Jsont.string ~enc:name
+  and+ book_count = mem "book_count" Jsont.int ~enc:book_count
+  and+ pseudo = mem "pseudo" Jsont.string ~enc:pseudo
+  and+ address = mem "address" Jsont.string ~enc:address
+  and+ email = mem "email" Jsont.string ~enc:email
+  in
+  { name; book_count; pseudo; address; email }
+
+let authors_jsont = Jsont.list author_jsont
+let authors_jsont_syntax = Jsont.list author_jsont_syntax    
+
+let streaming_gen st len make_rand jsont = (* Just for fun. *)
+  let enc f acc () =
+    let rec loop max i f acc =
+      if i > max then acc else loop max (i + 1) f (f acc i (make_rand st))
+    in
+    loop (len - 1) 0 f acc
+  in
+  Jsont.Array.array @@
+  Jsont.Array.map ~enc:Jsont.Array.{enc} jsont
+    
+let generate n file =
+  let st = Random.State.make_self_init () in
+  Out_channel.with_open_text file @@ fun oc ->
+  let w = Bytesrw.Bytes.Writer.of_out_channel oc in
+  let format = Jsont.Indent in
+  let gen = streaming_gen st n make_rand author_jsont in
+  match Jsont_bytesrw.encode ~format gen () ~eod:true w with
+  | Ok () -> 0
+  | Error e -> Printf.eprintf "%s\n%!" e; 1
+
+let decode file let_syntax =
+  let jsont = if let_syntax then authors_jsont_syntax else authors_jsont in
+  In_channel.with_open_text file @@ fun ic ->
+  let w = Bytesrw.Bytes.Reader.of_in_channel ic in
+  Sys.opaque_identity @@
+  match Jsont_bytesrw.decode jsont w with
+  | Ok v -> Sys.opaque_identity (ignore v); 0
+  | Error e -> Printf.eprintf "%s\n%!" e; 1
+
+let main () =
+  let usage = "Usage: test_syntax [OPTION]… FILE.json" in
+  let gen = ref false in
+  let n = ref 1_000_000 in
+  let file = ref None in
+  let let_syntax = ref false in
+  let args =
+    [ "--gen", Arg.Set gen, "Generate data";
+      "--n", Arg.Set_int n, "Number of records";
+      "--let-syntax", Arg.Set let_syntax, "Use let syntax"; ]
+  in
+  let pos s = match !file with
+  | Some _ -> raise (Arg.Bad (Printf.sprintf "Don't know what to do with %S" s))
+  | None -> file := Some s
+  in
+  Arg.parse args pos usage;
+  match !file with
+  | None -> prerr_endline "No file specified"; 1
+  | Some file -> if !gen then generate !n file else decode file !let_syntax
+
+let () = if !Sys.interactive then () else exit (main ())
+
+


### PR DESCRIPTION
Very nice library!

I had a superficial suggestion regarding the description of json objects. When the object contains a lot of fields, the positional ordering of the members could get out of sync with the `make` function arguments:

```ocaml
let make pseudo book_count name = { name; pseudo; book_count }
let jsont =
  Jsont.Object.map ~kind:"Author" make
  |> Jsont.Object.mem "name" Jsont.string ~enc:name
  |> Jsont.Object.mem "book_count" Jsont.int ~enc:book_count
  |> Jsont.Object.mem "pseudo" Jsont.string ~enc:pseudo
  |> Jsont.Object.finish
```

While careless mistakes are unavoidable, I like that custom binding operators can make it less likely to happen:

```ocaml
let jsont =
  let open Jsont.Object.Syntax in
  define ~kind:"Author" @@
  let+ name = mem "name" Jsont.string ~enc:name
  and+ book_count = mem "book_count" Jsont.int ~enc:book_count
  and+ pseudo = mem "pseudo" Jsont.string ~enc:pseudo
  in
  { name; book_count; pseudo }
```

Now this is arguably more verbose and it has a different aesthetic, so feel free to dismiss this PR if you don't like it :) (I had my fun with the GADT, which is enough satisfaction... The implementation is a bit tortuous to make the tree-shaped applicative conform with the existing `dec_fun` GADT.) Otherwise I'm happy to make any change you desire!

