### PR TITLE
allow indentation size to be configurable

### DIFF
--- a/src/jsont.ml
+++ b/src/jsont.ml
@@ -1281,16 +1281,15 @@ let pp_bool = Fmt.json_bool
 let pp_string = Fmt.json_string
 let pp_number = Fmt.json_number
 let pp_number' = Fmt.json_number'
-let pp_json' ?(number_format = Fmt.json_default_number_format) () ppf j =
-  let pp_indent = 2 in
+let pp_json' ?(indent_size = 2) ?(number_format = Fmt.json_default_number_format) () ppf j =
   let pp_sep ppf () =
     Format.pp_print_char ppf ',';
-    Format.pp_print_break ppf 1 pp_indent
+    Format.pp_print_break ppf 1 indent_size
   in
   let rec pp_array ppf a =
     Format.pp_open_hovbox ppf 0;
     Format.pp_print_char ppf '[';
-    Format.pp_print_break ppf 0 pp_indent;
+    Format.pp_print_break ppf 0 indent_size;
     (Format.pp_print_list ~pp_sep pp_value) ppf a;
     Format.pp_print_break ppf 0 0;
     Format.pp_print_char ppf ']';
@@ -1302,7 +1301,7 @@ let pp_json' ?(number_format = Fmt.json_default_number_format) () ppf j =
   and pp_obj ppf o =
     Format.pp_open_hvbox ppf 0;
     Format.pp_print_char ppf '{';
-    Format.pp_print_break ppf 0 pp_indent;
+    Format.pp_print_break ppf 0 indent_size;
     (Format.pp_print_list ~pp_sep pp_mem) ppf o;
     Format.pp_print_break ppf 0 0;
     Format.pp_print_char ppf '}';
@@ -2053,6 +2052,6 @@ let set_path ?stub ?(allow_absent = false) t p v = match Path.rev_indices p with
 type format = Minify | Indent | Layout
 type number_format = Fmt.json_number_format
 let default_number_format = Fmt.json_default_number_format
-let pp_value ?number_format t () = fun ppf v -> match Json.encode t v with
-| Ok j ->  pp_json' ?number_format () ppf j
+let pp_value ?indent_size ?number_format t () = fun ppf v -> match Json.encode t v with
+| Ok j ->  pp_json' ?indent_size ?number_format () ppf j
 | Error e -> pp_string ppf e

--- a/src/jsont.mli
+++ b/src/jsont.mli
@@ -1624,8 +1624,8 @@ val pp_string : string fmt
 val pp_json : json fmt
 (** [pp_json] formats JSON, see {!pp_json'}. *)
 
-val pp_json' : ?number_format:number_format -> unit -> json fmt
-(** [pp' ~format ~number_format () ppf j] formats [j] on [ppf]. The output
+val pp_json' : ?indent_size:int -> ?number_format:number_format -> unit -> json fmt
+(** [pp' ~format ~indent_size ~number_format () ppf j] formats [j] on [ppf]. The output
     is indented but may be more compact than an [Indent] JSON encoder may do.
     For example arrays may be output on one line if they fit etc.
     {ul
@@ -1635,7 +1635,7 @@ val pp_json' : ?number_format:number_format -> unit -> json fmt
        ({{!page-cookbook.non_finite_numbers}explanation}).}
     {- Strings are assumed to be valid UTF-8.}} *)
 
-val pp_value : ?number_format:number_format -> 'a t -> unit -> 'a fmt
+val pp_value : ?indent_size:int -> ?number_format:number_format -> 'a t -> unit -> 'a fmt
 (** [pp_value t ()] formats the JSON representation of values as
     described by [t] by encoding it with {!Json.val-encode} and formatting
     it with {!pp_json'}. If the encoding of the value errors a JSON


### PR DESCRIPTION
I wish to set my indentation size to 1 & then configure indentation to use tabs for accessibility.

```ocaml
let custom_formatter_functions : Format.formatter_out_functions =
	let sf = Format.pp_get_formatter_out_functions Format.std_formtter () in
	{ sf with out_indent = fun n -> sf.out_string (String.make n '\t') 0 n; }
in
Format.pp_set_formatter_out_functions ppf custom_formatter_functions;
```

---

I appreciate that there is a non-Microsoft-hosted mirror. I see the primary repository <https://erratique.ch/repos/jsont/> is at but neither it nor the homepage <https://erratique.ch/software/jsont> have any mention of how to contribute.