### PR TITLE
Allow Case.map to accept non-object types by auto-wrapping in value object

### DIFF
--- a/src/jsont.ml
+++ b/src/jsont.ml
@@ -1064,7 +1064,26 @@ module Object = struct
     Object { mems with mem_encs = List.rev mems.mem_encs }
 
   let get_object_map = function
-  | Object map -> map | _ -> invalid_arg "Not an object"
+  | Object map -> Some map | _ -> None
+
+  (* Wrap a non-object type in a synthetic object with a "value" member *)
+  let wrap_in_value_object (type a) (t : a Repr.t) : (a, a) object_map =
+    let make v = v in
+    let value v = v in
+    let id = Type.Id.make () in
+    let mem_map = { name = "value"; doc = ""; type' = t; id;
+                    dec_absent = None; enc = value;
+                    enc_omit = Fun.const false } in
+    let mem_decs = String_map.singleton "value" (Mem_dec mem_map) in
+    let mem_encs = [Mem_enc mem_map] in
+    let dec = Dec_app (Dec_fun make, id) in
+    let shape = Object_basic Unknown_skip in
+    { kind = ""; doc = ""; dec; mem_decs; mem_encs; enc_meta = enc_meta_none; shape }
+
+  let get_or_wrap_object_map t =
+    match get_object_map t with
+    | Some map -> map
+    | None -> wrap_in_value_object t
 
   (* Members *)
 
@@ -1110,7 +1129,7 @@ module Object = struct
 
     let no_dec _ = Error.msgf Meta.none "No decoder for case"
     let map ?(dec = no_dec) tag obj =
-      { tag; object_map = get_object_map obj; dec; }
+      { tag; object_map = get_or_wrap_object_map obj; dec; }
 
     let map_tag c = c.tag
     let make c = Case c

--- a/src/jsont.mli
+++ b/src/jsont.mli
@@ -1021,12 +1021,15 @@ module Object : sig
     val map :
       ?dec:('case -> 'cases) -> 'tag -> 'case jsont ->
       ('cases, 'case, 'tag) map
-    (** [map ~dec v obj] defines the object map [obj] as being the
-        case for the tag value [v] of the case member. [dec] indicates how to
-        inject the object case into the type common to all cases.
+    (** [map ~dec v t] defines the type [t] as being the case for the
+        tag value [v] of the case member. [dec] indicates how to inject
+        the case value into the type common to all cases.
 
-        Raises [Invalid_argument] if [obj] is not a direct result of
-        {!finish}, that is if [obj] does not describe an object. *)
+        If [t] is an object type (a direct result of {!finish}), its
+        members are merged into the parent object. Otherwise, [t] is
+        automatically wrapped in an object with a single ["value"] member.
+        For example, using [Jsont.int] as [t] will encode as
+        [{"type": "...", "value": 42}]. *)
 
     val map_tag : ('cases, 'case, 'tag) map -> 'tag
     (** [map_tag m] is [m]'s tag. *)


### PR DESCRIPTION
Non-object types passed to Case.map are automatically wrapped in a synthetic object with a single "value" member. This allows using primitive types like Jsont.int directly instead of requiring manual object wrappers.